### PR TITLE
Fix mediauploader editor bug

### DIFF
--- a/mqtranslate_javascript.php
+++ b/mqtranslate_javascript.php
@@ -220,7 +220,39 @@ function qtrans_initJS() {
 			}
 		}
 		";
-		
+	
+	$q_config['js']['qtrans_QTagsOverload'] = "
+		QTags.insertContent = function(content) {
+			var sel, startPos, endPos, scrollTop, text, canvas = document.getElementById('qtrans_textarea_content');
+
+			if ( !canvas ) {
+				return false;
+			}
+			if ( document.selection ) { //IE
+				canvas.focus();
+				sel = document.selection.createRange();
+				sel.text = content;
+				canvas.focus();
+			} else if ( canvas.selectionStart || canvas.selectionStart === 0 ) { // FF, WebKit, Opera
+				text = canvas.value;
+				startPos = canvas.selectionStart;
+				endPos = canvas.selectionEnd;
+				scrollTop = canvas.scrollTop;
+
+				canvas.value = text.substring(0, startPos) + content + text.substring(endPos, text.length);
+
+				canvas.focus();
+				canvas.selectionStart = startPos + content.length;
+				canvas.selectionEnd = startPos + content.length;
+				canvas.scrollTop = scrollTop;
+			} else {
+				canvas.value += content;
+				canvas.focus();
+			}
+			return true;
+		};
+		";
+	
 	$q_config['js']['qtrans_tinyMCEOverload'] = "
 		tinyMCE.get2 = tinyMCE.get;
 		tinyMCE.get = function(id) {

--- a/mqtranslate_wphacks.php
+++ b/mqtranslate_wphacks.php
@@ -184,6 +184,7 @@ function qtrans_modifyRichEditor($old_content) {
 	// make tinyMCE and mediauploader get the correct data
 	$content_append .=$q_config['js']['qtrans_tinyMCEOverload'];
 	$content_append .=$q_config['js']['qtrans_wpActiveEditorOverload'];
+	$content_append .=$q_config['js']['qtrans_QTagsOverload'];
 	$content_append .="}\n";
 	$content_append .=$q_config['js']['qtrans_editorInit'];
 	if($init_editor) {


### PR DESCRIPTION
That change should fix the problems described here: https://wordpress.org/support/topic/cannot-insert-images-in-text-editor?replies=13

The only difference from the original `QTags.insertContent` implementation is the new canvas assignment: `canvas = document.getElementById('qtrans_textarea_content');`

Would be great to see that in the next release.
