### PR TITLE
Fix: avoid ACF wysiwyg fields replace main content

### DIFF
--- a/mqtranslate_javascript.php
+++ b/mqtranslate_javascript.php
@@ -306,9 +306,9 @@ function qtrans_initJS() {
 				ed.on('SaveContent', function(e) {
 					if (!ed.isHidden()) {
 						e.content = e.content.replace( /<p>(<br ?\/?>|\u00a0|\uFEFF)?<\/p>/g, '<p>&nbsp;</p>' );
-						if ( ed.getParam( 'wpautop', true ) )
-							e.content = switchEditors.pre_wpautop(e.content);
-						qtrans_save(e.content);
+						if (ed.id.match(/^qtrans_/)) {
+							qtrans_save(switchEditors.pre_wpautop(e.content));
+						};
 					}
 				});
 				ed.on('init', function(e) {


### PR DESCRIPTION
Following next post in wordpress support forum:

https://wordpress.org/support/topic/problem-using-mqtranslate-wp-39-and-advanced-custom-fields

Tested and working in wp 4.0.1, ACF 4.3.9 and  mqtranslate 2.9